### PR TITLE
Fix TypeError in map.js

### DIFF
--- a/src/module/map.js
+++ b/src/module/map.js
@@ -73,7 +73,7 @@ const mateMap = {
 
 const nameSet = new Set([...$map.values()].flat());
 
-$map.keys().forEach(function(key){
+$map.forEach(function(value, key){
     if (key.match(/^[fm]/) || key.match(/^[olx][bs]$|^[olx][bs],[^mf]/)) {
         for (const k in mateMap) {
             let newKey = k + ',' + key;


### PR DESCRIPTION
Fix the error where $map.keys().forEach is not a function by using $map.forEach instead, as Map.keys() returns an Iterator which doesn't have the forEach method.